### PR TITLE
fix: reduce search scope

### DIFF
--- a/src/contract/flashNft.sol
+++ b/src/contract/flashNft.sol
@@ -6,9 +6,10 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 contract FlashNFT {
 
   function findToken(address _addr, uint256 _start, uint256 _end) public view returns (uint256[] memory) {
+    require(_end > _start, "findToken: end < start");
     ERC721Enumerable token = ERC721Enumerable(_addr);
     uint256[] memory ids;
-    ids = new uint256[](_end);
+    ids = new uint256[](_end - _start);
     uint256 index = 0;
     for (uint256 i = _start; i < _end; i++) {
       try token.ownerOf(i) returns (address owner) {


### PR DESCRIPTION
Reduce the return array size by limiting the scope to be from start to end.